### PR TITLE
Battle simulator show modal when battle is finished

### DIFF
--- a/src/app/battle-simulator/page.tsx
+++ b/src/app/battle-simulator/page.tsx
@@ -318,16 +318,22 @@ export default function BattleSimulator() {
         <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
           <div className='bg-white rounded-lg shadow-lg p-8 max-w-sm w-full text-center'>
             <h2 className='text-2xl font-bold mb-4'>Battle Finished!</h2>
+            <p className='mb-2 text-gray-600'>
+              {battleState.opponentHP <= 0 ? 'You won!' : 'You lost!'}
+            </p>
             <p className='mb-6'>Return to the Pokemons</p>
             <button
+              autoFocus
               className='bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 transition'
-              onClick={() => {
-                setShowBattleFinishedModal(false);
-                if (resetTimeoutRef.current) {
-                  clearTimeout(resetTimeoutRef.current);
-                  resetTimeoutRef.current = null;
+              onClick={(e) => {
+                if (e.target === e.currentTarget) {
+                  setShowBattleFinishedModal(false);
+                  if (resetTimeoutRef.current) {
+                    clearTimeout(resetTimeoutRef.current);
+                    resetTimeoutRef.current = null;
+                  }
+                  resetBattle();
                 }
-                resetBattle();
               }}
             >
               Back to Pokemons


### PR DESCRIPTION
- It should be clear when a battle is finished, this is done by adding a modal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a modal dialog to notify users when a battle finishes, providing clear feedback and an option to manually reset the battle.
- **Improvements**
  - Enhanced battle reset timing to prevent overlapping resets and ensure smoother transitions between battles.
  - Increased the delay for the opponent's turn for a more natural pacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->